### PR TITLE
chore: Upgrade the release pipeline to v4

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/nozaq/terraform-aws-secure-baseline
+  repository_url: https://github.com/Unumed/terraform-aws-secure-baseline
 options:
   commits:
     filters:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: terraform-module
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
The current version of release pipeline action has been archived, Upgrading to v4